### PR TITLE
Make AutomailerSpool extend Swift_FileSpool

### DIFF
--- a/Library/AutomailerSpool.php
+++ b/Library/AutomailerSpool.php
@@ -4,7 +4,7 @@ namespace TSS\AutomailerBundle\Library;
 
 use TSS\AutomailerBundle\Entity\Automailer as Am;
 
-class AutomailerSpool extends \Swift_ConfigurableSpool
+class AutomailerSpool extends \Swift_FileSpool
 {
     /**
      * The Entity Manager


### PR DESCRIPTION
So that swiftmailer:spool:send does recover operation for automailer as well.

This might be a bit ugly since automailer is not a file based spool. The proper way is for swiftmailer to provide a RecoverableSpoolInterface so that FileSpool and AutomailerSpool implements it, then tries to recover in the SendMailCommand if the spool implements that interface.

Nevertheless, this should allow swiftmailer:spool:send command to do recovery for AutomailerSpool without any side effects.

This also makes automailer:spool:send obsolete.
