### PR TITLE
Add indexes to the database table

### DIFF
--- a/Entity/Automailer.php
+++ b/Entity/Automailer.php
@@ -6,7 +6,13 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * TSS\AutomailerBundle\Entity\Automailer
- * @ORM\Table(name="automailer")
+ * @ORM\Table(
+ *     name="automailer",
+ *     indexes={
+ *         @ORM\Index(name="find_next", columns={"is_sent", "is_failed", "is_sending", "created_at"}),
+ *         @ORM\Index(name="recover_sending", columns={"is_sending", "started_sending_at"}),
+ *     }
+ * )
  * @ORM\Entity(repositoryClass="TSS\AutomailerBundle\Entity\AutomailerRepository")
  */
 class Automailer

--- a/Resources/sql/automailer.sql
+++ b/Resources/sql/automailer.sql
@@ -13,5 +13,7 @@ CREATE TABLE IF NOT EXISTS `automailer` (
   `alt_body` longtext NOT NULL,
   `is_sending` tinyint(1) DEFAULT NULL,
   `swift_message` longtext NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `find_next` (`is_sent`,`is_failed`,`is_sending`,`created_at`),
+  KEY `recover_sending` (`is_sending`,`started_sending_at`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 AUTO_INCREMENT=1 ;


### PR DESCRIPTION
I am using automailer on a very large site. The sheer amount of items in the automailer table made it very slow just to query out the new items to send.

Adding appropriate indexes on the table should help with this problem.
