### PR TITLE
Made composer.json requirements be less restrictive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "swiftmailer/swiftmailer": ">=4.2.0,<4.4-dev",
-        "symfony/swiftmailer-bridge": ">=2.1,<3.0",
-        "symfony/swiftmailer-bundle": "2.3.*,>=2.1.0"
+        "swiftmailer/swiftmailer": " >=4.2.0",
+        "symfony/swiftmailer-bridge": ">=2.1",
+        "symfony/swiftmailer-bundle": ">=2.1.0"
     },
     "suggest": {
         "beanstalkd-binary": "http://kr.github.com/beanstalkd/",


### PR DESCRIPTION
This allows the use of the bundle with newer versions of swiftmailer, swiftmailer-bridge and swiftmailer-bundle because FOSUserBundle 2.0.x-dev requires them.
