### PR TITLE
Update services.xml

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -14,6 +14,8 @@
             <argument type="service" id="doctrine.orm.entity_manager" />
         </service>
 
+        <service id="swiftmailer.mailer.default.spool.automailer" alias="swiftmailer.spool.automailer" />
+
         <service id="automailer.plugin.beanstalk" class="%automailer.plugin.beanstalk.class%" public="false">
             <argument type="service" id="service_container" />
         </service>


### PR DESCRIPTION
Fixes:

```
  [Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]
  Unable to replace alias "swiftmailer.mailer.default.spool.automailer" with "swiftmailer.mailer.default.spool".

  [Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]
  The service definition "swiftmailer.mailer.default.spool.automailer" does not exist.
```
